### PR TITLE
Adding debounce for optimisation purpose

### DIFF
--- a/examples/backbone/js/views/app-view.js
+++ b/examples/backbone/js/views/app-view.js
@@ -38,7 +38,7 @@ var app = app || {};
 			this.listenTo(app.todos, 'reset', this.addAll);
 			this.listenTo(app.todos, 'change:completed', this.filterOne);
 			this.listenTo(app.todos, 'filter', this.filterAll);
-			this.listenTo(app.todos, 'all', this.render);
+			this.listenTo(app.todos, 'all', _.debounce(this.render));
 
 			// Suppresses 'add' events with {reset: true} and prevents the app view
 			// from being re-rendered for every model. Only renders when the 'reset'


### PR DESCRIPTION
Listening to all collection events is very greedy, so I use debounce to render the app view once all events are triggered.
